### PR TITLE
use aquamarine 0.1 branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ num-traits = "0.2.14"
 chrono = "0.4"
 tensorboard-rs = "0.2.4"
 thiserror = "1.0"
-aquamarine = "0.1.6"
+aquamarine = "0.1"
 
 [[example]]
 name = "random_cartpole"


### PR DESCRIPTION
Aquamarine has been updated to support offline mode in 0.1.8, and doesn't require internet connection to build and view the rendered diagrams anymore.

This change switches from pinned patch version to a the 0.1 branch in order to include the offline more feature and other backward-compatible improvements coming in future