### PR TITLE
Allow choosing the torch device to store replay buffer

### DIFF
--- a/border-tch-agent/src/dqn/builder.rs
+++ b/border-tch-agent/src/dqn/builder.rs
@@ -139,7 +139,7 @@ impl DQNBuilder {
     /// Constructs DQN agent.
     ///
     /// This is used with non-vectorized environments.
-    pub fn build<E, Q, O, A>(self, qnet: DQNModel<Q>, device: tch::Device) -> DQN<E, Q, O, A>
+    pub fn build<E, Q, O, A>(self, qnet: DQNModel<Q>, device: tch::Device, replay_buffer_device: tch::Device) -> DQN<E, Q, O, A>
     where
         E: Env,
         Q: SubModel<Output = Tensor>,
@@ -149,7 +149,7 @@ impl DQNBuilder {
         A: TchBuffer<Item = E::Act, SubBatch = Tensor>, // Todo: consider replacing Tensor with M::Output
     {
         let qnet_tgt = qnet.clone();
-        let replay_buffer = ReplayBuffer::new(self.replay_burffer_capacity);
+        let replay_buffer = ReplayBuffer::new(self.replay_burffer_capacity, replay_buffer_device);
 
         DQN {
             qnet,

--- a/border-tch-agent/src/iqn/builder.rs
+++ b/border-tch-agent/src/iqn/builder.rs
@@ -153,6 +153,7 @@ impl IQNBuilder {
         self,
         iqn_model: IQNModel<F, M>,
         device: Device,
+        replay_buffer_device: Device,
     ) -> IQN<E, F, M, O, A>
     where
         E: Env,
@@ -165,7 +166,7 @@ impl IQNBuilder {
     {
         let iqn = iqn_model;
         let iqn_tgt = iqn.clone();
-        let replay_buffer = ReplayBuffer::new(self.replay_buffer_capacity);
+        let replay_buffer = ReplayBuffer::new(self.replay_buffer_capacity, replay_buffer_device);
 
         IQN {
             iqn,

--- a/border-tch-agent/src/replay_buffer.rs
+++ b/border-tch-agent/src/replay_buffer.rs
@@ -64,11 +64,11 @@ where
     ///
     /// Input argument `_n_proc` is not used.
     /// TODO: remove n_procs
-    fn new(capacity: usize) -> Self {
+    fn new(capacity: usize, device: Device) -> Self {
         let capacity = capacity as i64;
         let mut shape: Vec<_> = S::shape().to_vec().iter().map(|e| *e as i64).collect();
         shape.insert(0, capacity);
-        let buf = D::zeros(shape.as_slice());
+        let buf = D::zeros(shape.as_slice()).to(device);
 
         Self {
             buf,
@@ -92,5 +92,9 @@ where
     /// Creates minibatch.
     fn batch(&self, batch_indexes: &Tensor) -> Tensor {
         self.buf.index_select(0, &batch_indexes)
+    }
+
+    fn device(&self) -> Option<tch::Device> {
+        Some(self.buf.device())
     }
 }

--- a/border-tch-agent/src/sac/base.rs
+++ b/border-tch-agent/src/sac/base.rs
@@ -63,7 +63,7 @@ where
     P: SubModel<Input = O::SubBatch, Output = (ActMean, ActStd)>,
     E::Obs: Into<O::SubBatch>,
     E::Act: From<Tensor>,
-    O: TchBuffer<Item = E::Obs>,
+    O: TchBuffer<Item = E::Obs, SubBatch = Tensor>,
     A: TchBuffer<Item = E::Act, SubBatch = Tensor>,
 {
     // Adapted from dqn.rs
@@ -128,9 +128,9 @@ where
         trace!("SAC::update_critic()");
 
         let losses = {
-            let o = &batch.obs;
+            let o = &batch.obs.to(self.device);
             let a = &batch.actions.to(self.device);
-            let next_o = &batch.next_obs;
+            let next_o = &batch.next_obs.to(self.device);
             let r = &batch.rewards.to(self.device).squeeze();
             let not_done = &batch.not_dones.to(self.device).squeeze();
 
@@ -171,7 +171,7 @@ where
         trace!("SAC::update_actor()");
 
         let loss = {
-            let o = &batch.obs;
+            let o = &batch.obs.to(self.device);
             let (a, log_p) = self.action_logp(o);
 
             // Update the entropy coefficient
@@ -224,7 +224,7 @@ where
     P: SubModel<Input = O::SubBatch, Output = (ActMean, ActStd)>,
     E::Obs: Into<O::SubBatch>,
     E::Act: From<Tensor>,
-    O: TchBuffer<Item = E::Obs>,
+    O: TchBuffer<Item = E::Obs, SubBatch = Tensor>,
     A: TchBuffer<Item = E::Act, SubBatch = Tensor>,
 {
     fn train(&mut self) {

--- a/border-tch-agent/src/sac/builder.rs
+++ b/border-tch-agent/src/sac/builder.rs
@@ -156,6 +156,7 @@ impl SACBuilder {
         critics: Vec<Critic<Q>>,
         policy: Actor<P>,
         device: tch::Device,
+        replay_buffer_device: tch::Device,
     ) -> SAC<E, Q, P, O, A>
     where
         E: Env,
@@ -167,7 +168,7 @@ impl SACBuilder {
         A: TchBuffer<Item = E::Act, SubBatch = Tensor>,
     {
         let critics_tgt = critics.to_vec();
-        let replay_buffer = ReplayBuffer::new(self.replay_burffer_capacity);
+        let replay_buffer = ReplayBuffer::new(self.replay_burffer_capacity, replay_buffer_device);
 
         SAC {
             qnets: critics,

--- a/examples/dqn_atari.rs
+++ b/examples/dqn_atari.rs
@@ -75,7 +75,7 @@ fn create_agent(
     let agent_cfg = DQNBuilder::load(Path::new(&agent_cfg))?;
     let agent = agent_cfg
         .clone()
-        .build::<_, _, ObsBuffer, ActBuffer>(qnet, device);
+        .build::<_, _, ObsBuffer, ActBuffer>(qnet, device, tch::Device::Cpu);
 
     Ok((agent, agent_cfg))
 }

--- a/examples/dqn_atari_vec.rs
+++ b/examples/dqn_atari_vec.rs
@@ -77,7 +77,7 @@ fn create_agent(
     let agent_cfg = DQNBuilder::load(Path::new(&agent_cfg))?;
     let agent = agent_cfg
         .clone()
-        .build::<_, _, ObsBuffer, ActBuffer>(qnet, device);
+        .build::<_, _, ObsBuffer, ActBuffer>(qnet, device, tch::Device::Cpu);
 
     Ok((agent, agent_cfg))
 }

--- a/examples/dqn_cartpole.rs
+++ b/examples/dqn_cartpole.rs
@@ -187,7 +187,7 @@ fn create_agent(epsilon_greedy: bool) -> Result<impl Agent<Env>> {
     } else {
         builder
     }
-    .build::<_, _, ObsBuffer, ActBuffer>(qnet, device))
+    .build::<_, _, ObsBuffer, ActBuffer>(qnet, device, tch::Device::Cpu))
 }
 
 fn create_env() -> Env {

--- a/examples/iqn_atari.rs
+++ b/examples/iqn_atari.rs
@@ -238,7 +238,7 @@ fn create_agent(
     let agent_cfg = IQNBuilder::load(Path::new(&agent_cfg))?;
     let agent = agent_cfg
         .clone()
-        .build::<_, _, _, ObsBuffer, ActBuffer>(iqn, device);
+        .build::<_, _, _, ObsBuffer, ActBuffer>(iqn, device, tch::Device::Cpu);
 
     Ok((agent, agent_cfg))
 }

--- a/examples/iqn_cartpole.rs
+++ b/examples/iqn_cartpole.rs
@@ -241,7 +241,7 @@ fn create_agent() -> impl Agent<Env> {
         .soft_update_interval(SOFT_UPDATE_INTERVAL)
         .explorer(EpsilonGreedy::with_params(EPS_START, EPS_FINAL, FINAL_STEP))
         .replay_buffer_capacity(REPLAY_BUFFER_CAPACITY)
-        .build::<_, _, _, ObsBuffer, ActBuffer>(iqn_model, device)
+        .build::<_, _, _, ObsBuffer, ActBuffer>(iqn_model, device, tch::Device::Cpu)
 }
 
 fn create_env() -> Env {

--- a/examples/sac_ant.rs
+++ b/examples/sac_ant.rs
@@ -111,7 +111,7 @@ fn create_agent() -> Result<impl Agent<Env>> {
         .reward_scale(REWARD_SCALE)
         .critic_loss(CRITIC_LOSS)
         .replay_burffer_capacity(REPLAY_BUFFER_CAPACITY)
-        .build::<_, _, _, ObsBuffer, ActBuffer>(critics, actor, device))
+        .build::<_, _, _, ObsBuffer, ActBuffer>(critics, actor, device, tch::Device::Cpu))
 }
 
 fn create_env() -> Env {

--- a/examples/sac_lunarlander_cont.rs
+++ b/examples/sac_lunarlander_cont.rs
@@ -127,7 +127,7 @@ fn create_agent() -> Result<impl Agent<Env>> {
         .reward_scale(REWARD_SCALE)
         .critic_loss(CRITIC_LOSS)
         .replay_burffer_capacity(REPLAY_BUFFER_CAPACITY)
-        .build::<_, _, _, ObsBuffer, ActBuffer>(critics, actor, device))
+        .build::<_, _, _, ObsBuffer, ActBuffer>(critics, actor, device, tch::Device::Cpu))
 }
 
 fn create_env() -> Env {

--- a/examples/sac_lunarlander_cont_vec.rs
+++ b/examples/sac_lunarlander_cont_vec.rs
@@ -111,7 +111,7 @@ fn create_agent() -> Result<impl Agent<Env>> {
         .reward_scale(REWARD_SCALE)
         .critic_loss(CRITIC_LOSS)
         .replay_burffer_capacity(REPLAY_BUFFER_CAPACITY)
-        .build::<_, _, _, ObsBuffer, ActBuffer>(critics, actor, device))
+        .build::<_, _, _, ObsBuffer, ActBuffer>(critics, actor, device, tch::Device::Cpu))
 }
 
 fn create_env(n_procs: usize) -> Env {

--- a/examples/sac_pendulum.rs
+++ b/examples/sac_pendulum.rs
@@ -338,7 +338,7 @@ fn create_agent() -> Result<impl Agent<Env>> {
         .reward_scale(REWARD_SCALE)
         .critic_loss(CRITIC_LOSS)
         .replay_burffer_capacity(REPLAY_BUFFER_CAPACITY)
-        .build::<_, _, _, ObsBuffer, ActBuffer>(critics, actor, device))
+        .build::<_, _, _, ObsBuffer, ActBuffer>(critics, actor, device, tch::Device::Cpu))
 }
 
 fn create_env() -> Env {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@
 //!         .tau(TAU)
 //!         .replay_burffer_capacity(REPLAY_BUFFER_CAPACITY)
 //!         .explorer(DQNExplorer::EpsilonGreedy(EpsilonGreedy::new()))
-//!         .build::<_, _, ObsBuffer, ActBuffer>(qnet, device))
+//!         .build::<_, _, ObsBuffer, ActBuffer>(qnet, device, tch::Device::Cpu))
 //! }
 //!
 //! fn create_env() -> Env {
@@ -318,7 +318,7 @@
 //! #         .tau(TAU)
 //! #         .replay_burffer_capacity(REPLAY_BUFFER_CAPACITY)
 //! #         .explorer(DQNExplorer::EpsilonGreedy(EpsilonGreedy::new()))
-//! #         .build::<_, _, ObsBuffer, ActBuffer>(qnet, device))
+//! #         .build::<_, _, ObsBuffer, ActBuffer>(qnet, device, tch::Device::Cpu))
 //! # }
 //! #
 //! # fn create_env() -> Env {


### PR DESCRIPTION
This avoids the need to copy replay buffer samples from CPU to GPU every training step. However, if GPU RAM is insufficient, replay buffer can be kept on CPU.

This requires `Obs` to be a `Tensor` (`Act` already is).